### PR TITLE
Remove forced restart if app wasn't started through Steam

### DIFF
--- a/Assets/Scripts/Steamworks.NET/SteamManager.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamManager.cs
@@ -69,45 +69,28 @@ public class SteamManager : MonoBehaviour {
 		}
 
 		try {
-			// If Steam is not running or the game wasn't started through Steam, SteamAPI_RestartAppIfNecessary starts the
-			// Steam client and also launches this game again if the User owns it. This can act as a rudimentary form of DRM.
+			// Initializes the Steamworks API.
+			// If this returns false then this indicates one of the following conditions:
+			// [*] The Steam client isn't running. A running Steam client is required to provide implementations of the various Steamworks interfaces.
+			// [*] The Steam client couldn't determine the App ID of game. If you're running your application from the executable or debugger directly then you must have a [code-inline]steam_appid.txt[/code-inline] in your game directory next to the executable, with your app ID in it and nothing else. Steam will look for this file in the current working directory. If you are running your executable from a different directory you may need to relocate the [code-inline]steam_appid.txt[/code-inline] file.
+			// [*] Your application is not running under the same OS user context as the Steam client, such as a different user or administration access level.
+			// [*] Ensure that you own a license for the App ID on the currently active Steam account. Your game must show up in your Steam library.
+			// [*] Your App ID is not completely set up, i.e. in [code-inline]Release State: Unavailable[/code-inline], or it's missing default packages.
+			// Valve's documentation for this is located here:
+			// https://partner.steamgames.com/doc/sdk/api#initialization_and_shutdown
+			m_bInitialized = SteamAPI.Init();
+			if (!m_bInitialized) {
+				Debug.LogError("[Steamworks.NET] SteamAPI_Init() failed. Refer to Valve's documentation or the comment above this line for more information.", this);
 
-			// Once you get a Steam AppID assigned by Valve, you need to replace AppId_t.Invalid with it and
-			// remove steam_appid.txt from the game depot. eg: "(AppId_t)480" or "new AppId_t(480)".
-			// See the Valve documentation for more information: https://partner.steamgames.com/doc/sdk/api#initialization_and_shutdown
-			
-			// if (SteamAPI.RestartAppIfNecessary(AppId_t.Invalid)) 
-			
-			if (SteamAPI.RestartAppIfNecessary( ((AppId_t) 689580) ))
-			{
-				Application.Quit();
 				return;
 			}
+
+			s_EverInialized = true;
 		}
 		catch (System.DllNotFoundException e) { // We catch this exception here, as it will be the first occurence of it.
 			Debug.LogError("[Steamworks.NET] Could not load [lib]steam_api.dll/so/dylib. It's likely not in the correct location. Refer to the README for more details.\n" + e, this);
-
-			Application.Quit();
 			return;
 		}
-
-		// Initializes the Steamworks API.
-		// If this returns false then this indicates one of the following conditions:
-		// [*] The Steam client isn't running. A running Steam client is required to provide implementations of the various Steamworks interfaces.
-		// [*] The Steam client couldn't determine the App ID of game. If you're running your application from the executable or debugger directly then you must have a [code-inline]steam_appid.txt[/code-inline] in your game directory next to the executable, with your app ID in it and nothing else. Steam will look for this file in the current working directory. If you are running your executable from a different directory you may need to relocate the [code-inline]steam_appid.txt[/code-inline] file.
-		// [*] Your application is not running under the same OS user context as the Steam client, such as a different user or administration access level.
-		// [*] Ensure that you own a license for the App ID on the currently active Steam account. Your game must show up in your Steam library.
-		// [*] Your App ID is not completely set up, i.e. in [code-inline]Release State: Unavailable[/code-inline], or it's missing default packages.
-		// Valve's documentation for this is located here:
-		// https://partner.steamgames.com/doc/sdk/api#initialization_and_shutdown
-		m_bInitialized = SteamAPI.Init();
-		if (!m_bInitialized) {
-			Debug.LogError("[Steamworks.NET] SteamAPI_Init() failed. Refer to Valve's documentation or the comment above this line for more information.", this);
-
-			return;
-		}
-
-		s_EverInialized = true;
 	}
 
 	// This should only ever get called on first load and after an Assembly reload, You should never Disable the Steamworks Manager yourself.


### PR DESCRIPTION
The SteamManager class forces the application to shut down if it wasn't started through Steam. This blocks all attempts at running TurnSignal outside of Steam so the hours in it aren't tracked (#27).

This request simply removes calls to `Application.Quit()` and `SteamAPI.RestartAppIfNecessary` in `SteamManager.cs`

With this change, you can fix #27 by just running the exe directly.

Note: My Unity is bugged (haven't touched it for ages) so I couldn't test a build but it compiles fine in the Mono editor.